### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -1,6 +1,9 @@
 class ItemsController < ApplicationController
   # deviseのメソッド。before_actionで呼び出すことで、アクションを実行する前にログインしていなければログイン画面に遷移させられる。
   before_action :authenticate_user!, only: [:new]
+  # 編集と詳細
+  before_action :set_item, only: [:show, :edit]
+  # before_action :set_postage, only: [:show, :index]
 
   def index
     # includesメソッド モデル.includes(:アソシエーションを組んでいるモデル):引数に指定された関連モデルを1度のアクセスでまとめて取得。処理の回数を減らしてパフォーマンスが著しく下がることを防ぐ。
@@ -24,9 +27,30 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:name, :detail, :category_id, :state_id, :postage_id, :prefecture_id, :shipping_date_id, :price, :image).merge(user_id: current_user.id)
   end
+
+  # 例えばshowのviewファイルで@itemを使って、userIdを取得できているのは⬇︎ここで値を変数化して使える状態にしているから
+  # .find(params[:id])　　　　　　　　　　　　　　　　　　　　　　　　
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  # def set_postage
+  # end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,12 @@ class Item < ApplicationRecord
   # 指定したファイル名は、そのモデルが設けたフォームから送られるパラメーターのキーにもなります。＝＞itemディレクトリのview内、form_withの中にあるimageは、ファイルを格納するキーにもなる
   has_one_attached :image
   belongs_to :user
+  has_one :order
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to :category, :state, :postage, :prefecture, :shipping_date
+  belongs_to :category
+  belongs_to :state
+  belongs_to :postage
+  belongs_to :prefecture
+  belongs_to :shipping_date
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,4 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item,local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
       <% @items.each do |item| %>
       <li class='list'>
-        <% link_to items_path %>
+        <%= link_to item_path(item.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -143,15 +143,18 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.postage_id %></span>
+                                        <%# itemモデルがアソシエーションで組んでいるActiveHashのデータを引き出す時は、belongs_to で紐付けたモデル名をつなげる %>
+            <span><%= item.price %>円<br><%= item.postage.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+        <% end %>
       </li>
       <% end %>
+      
       <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,10 +31,8 @@
       <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>
-    <% end %>
-    <% if user_signed_in? && !(current_user.id == @item.user_id) %>
-        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% else user_signed_in? && !(current_user.id == @item.user_id) %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
     <%# @変数.user_id の書き方：%>
   
-    <% if user_signed_in? && current_user.id == @item.user_id %>
+    <% if user_signed_in? && current_user.id && @item.user_id && @item.order.blank? %>
       <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,6 +8,7 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
+
       <% if @item.order.present? %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -24,19 +25,17 @@
       </span>
     </div>
 
-  <%# @変数.user_id の書き方：%>
-  <% if user_signed_in? && current_user.id == @item.user_id %>
-    <% if '商品詳細画面にアクセスしたユーザーが出品者かどうか' %>
+    <%# @変数.user_id の書き方：%>
+  
+    <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>
-    <% elsif @item.order.blank? %>
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
-  <% end %>
-
+    <% if user_signed_in? %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -47,7 +46,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.name %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-
-      <% if @item.order.present? %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %> 
+      <%# //<% if @item.order.blank? %>
+      <%# //<div class='sold-out'>
+        <%# //<span>Sold Out!!</span>
+      <%# //</div>
       <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
@@ -21,18 +21,18 @@
         <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= @postageName %>
+        <%= @item.postage.name %>
       </span>
     </div>
 
     <%# @変数.user_id の書き方：%>
   
-    <% if user_signed_in? && current_user.id && @item.user_id && @item.order.blank? %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>
     <% end %>
-    <% if user_signed_in? && current_user.id == @item.user_id? %>
+    <% if user_signed_in? && !(current_user.id == @item.user_id) %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
         <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
@@ -40,7 +40,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.detail %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -105,7 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,7 +32,7 @@
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>
     <% end %>
-    <% if user_signed_in? %>
+    <% if user_signed_in? && current_user.id == @item.user_id? %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
         <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,34 +4,38 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <% if @item.order.present? %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @postageName %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+  <%# @変数.user_id の書き方：%>
+  <% if user_signed_in? && current_user.id == @item.user_id %>
+    <% if '商品詳細画面にアクセスしたユーザーが出品者かどうか' %>
+      <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>
+    <% elsif @item.order.blank? %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+  <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
@@ -43,27 +47,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.state.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create] 
+  resources :items, only: [:index, :new, :create, :show, :edit, :destroy] 
 end

--- a/db/migrate/20201205113019_create_orders.rb
+++ b/db/migrate/20201205113019_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user,              foreign_key: true
+      t.references :item,              foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_063356) do
+ActiveRecord::Schema.define(version: 2020_12_05_113019) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2020_12_02_063356) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "item_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "first_name", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2020_12_02_063356) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :order do
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
＃What
商品詳細表示機能実装
rubocop実行

・ログイン中のみ「編集・削除ボタン」が表示される
https://gyazo.com/cc49a22d820c7ee61236ceaf1846fb00
・ログアウトでも、商品詳細表示ページを閲覧できる　/
　ログアウトでは、「編集・削除・購入画面に進むボタン」が表示されないこと　/
    商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/d632fd3ece7430861b19ef56171c460f
・ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/39e6278315c982256e4c09fea47b8e5f

＃Why
商品内容を確認できるようにするため