### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
   # deviseのメソッド。before_actionで呼び出すことで、アクションを実行する前にログインしていなければログイン画面に遷移させられる。
   before_action :authenticate_user!, only: [:new]
-  # 編集と詳細
+  # 編集と詳細は誰のページなのか
   before_action :set_item, only: [:show, :edit]
-  # before_action :set_postage, only: [:show, :index]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     # includesメソッド モデル.includes(:アソシエーションを組んでいるモデル):引数に指定された関連モデルを1度のアクセスでまとめて取得。処理の回数を減らしてパフォーマンスが著しく下がることを防ぐ。
@@ -34,6 +34,12 @@ class ItemsController < ApplicationController
   end
 
   def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item.id)
+    else
+      render :edit
+    end
   end
 
   def destroy
@@ -46,11 +52,15 @@ class ItemsController < ApplicationController
   end
 
   # 例えばshowのviewファイルで@itemを使って、userIdを取得できているのは⬇︎ここで値を変数化して使える状態にしているから
-  # .find(params[:id])　　　　　　　　　　　　　　　　　　　　　　　　
+  # 確認：.find(params[:id])
   def set_item
     @item = Item.find(params[:id])
   end
 
-  # def set_postage
-  # end
+  def move_to_index
+    unless user_signed_in? && current_user == @item.user
+      redirect_to action: :index
+    end
+  end
 end
+

--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -57,6 +57,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to action: :index  current_user == @item.user
+    redirect_to action: :index unless current_user == @item.user
   end
 end

--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   # deviseのメソッド。before_actionで呼び出すことで、アクションを実行する前にログインしていなければログイン画面に遷移させられる。
   before_action :authenticate_user!, only: [:new]
   # 編集と詳細は誰のページなのか
-  before_action :set_item, only: [:show, :edit]
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :move_to_index, only: [:edit]
 
   def index

--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -58,9 +58,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    unless user_signed_in? && current_user == @item.user
-      redirect_to action: :index
-    end
+    redirect_to action: :index unless user_signed_in? && current_user == @item.user
   end
 end
-

--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -34,7 +34,6 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item.id)
     else
@@ -58,6 +57,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to action: :index unless user_signed_in? && current_user == @item.user
+    redirect_to action: :index  current_user == @item.user
   end
 end

--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   # deviseのメソッド。before_actionで呼び出すことで、アクションを実行する前にログインしていなければログイン画面に遷移させられる。
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new, :edit]
   # 編集と詳細は誰のページなのか
   before_action :set_item, only: [:show, :edit, :update]
   before_action :move_to_index, only: [:edit]

--- a/app/controllers/Items_controller.rb
+++ b/app/controllers/Items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   # 編集と詳細は誰のページなのか
   before_action :set_item, only: [:show, :edit]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :move_to_index, only: [:edit]
 
   def index
     # includesメソッド モデル.includes(:アソシエーションを組んでいるモデル):引数に指定された関連モデルを1度のアクセスでまとめて取得。処理の回数を減らしてパフォーマンスが著しく下がることを防ぐ。

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item,local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :detail, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:state_id, State.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_id, Postage.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,8 +25,6 @@
       </span>
     </div>
 
-    <%# @変数.user_id の書き方：%>
-  
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,8 +25,8 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.id %>
-      <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>
     <% else user_signed_in? && !(current_user.id == @item.user_id) %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
+    <% if user_signed_in? && current_user.id == @item.id %>
       <%= link_to '商品の編集', edit_item_path(@item.user_id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.user_id), method: :delete, class:'item-destroy' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :destroy] 
+  resources :items
 end


### PR DESCRIPTION
＃What
商品情報編集機能実装
rubocop実行

・ログイン状態の出品者だけが商品情報編集ページに遷移できる,
    商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）,
　商品出品時とほぼ同じ見た目で商品情報編集機能が実装されている
https://gyazo.com/c5e8f190b7ebd84fb6e6a687106c8a72
・何も編集せずに更新をしても画像無しの商品にならない
https://gyazo.com/b2de44aad377bd664c979615a0032ce4
・必要な情報を適切に入力すると、商品情報を変更できる
https://gyazo.com/516dd304df132f0e40e25fdab6268a07
・適切では無い値が入力された場合、エラーメッセージの出力は、商品情報編集ページにてエラーメッセージが出力させる
https://gyazo.com/2704631ab8bed6b79f2c47e16d26db9d
・ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する
https://gyazo.com/549aae0ba91bf3e7a8f9e32a877e4a82
・ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する
https://gyazo.com/638e2bcf5801bc4bab0c126b49955940

＃Why
正しく編集機能を使えるようにするため